### PR TITLE
Improve CLI usage handling utilizing Boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb -O3 -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb -O3 -Wall")
 
-find_package(Boost 1.53.0 REQUIRED)
+find_package(Boost 1.53.0 REQUIRED COMPONENTS program_options)
 
 file(GLOB LIBFST_SRC ${PROJECT_SOURCE_DIR}/fst/fstapi.c 
                      ${PROJECT_SOURCE_DIR}/fst/fastlz.c 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb -O3 -Wall")
 find_package(Boost 1.53.0 REQUIRED COMPONENTS program_options)
 
 ExternalProject_Add(rxterm
-    #GIT_REPOSITORY    git@github.com:olehzdubna/rxterm.git
-    GIT_REPOSITORY    git@github.com:maxsteciuk/rxterm.git
+    GIT_REPOSITORY    git@github.com:olehzdubna/rxterm.git
     BUILD_IN_SOURCE true
     PREFIX ${CMAKE_BINARY_DIR}
     INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_BINARY_DIR}/src/rxterm/rxterm/include ${CMAKE_SOURCE_DIR}/rxterm-headers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,22 @@
 cmake_minimum_required(VERSION 3.15)
 project(FastOutReader)
 
-set(CMAKE_CXX_STANDARD 11)
+include(ExternalProject)
+
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb -O3 -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb -O3 -Wall")
 
 find_package(Boost 1.53.0 REQUIRED COMPONENTS program_options)
+
+ExternalProject_Add(rxterm
+    #GIT_REPOSITORY    git@github.com:olehzdubna/rxterm.git
+    GIT_REPOSITORY    git@github.com:maxsteciuk/rxterm.git
+    BUILD_IN_SOURCE true
+    PREFIX ${CMAKE_BINARY_DIR}
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_BINARY_DIR}/src/rxterm/rxterm/include ${CMAKE_SOURCE_DIR}/rxterm-headers
+)
 
 file(GLOB LIBFST_SRC ${PROJECT_SOURCE_DIR}/fst/fstapi.c 
                      ${PROJECT_SOURCE_DIR}/fst/fastlz.c 
@@ -18,8 +28,15 @@ add_library(fst ${LIBFST_SRC} ${LIBFST_HDR})
 
 include_directories(${PROJECT_SOURCE_DIR})
 file(GLOB FASTREAD_SRC ${PROJECT_SOURCE_DIR}/*.cpp)
+
+
 add_executable(fastread ${FASTREAD_SRC})
-target_include_directories(fastread PUBLIC ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/fst)
+add_dependencies(fastread rxterm)
+target_include_directories(fastread PUBLIC 
+                          ${PROJECT_SOURCE_DIR} 
+			  ${PROJECT_SOURCE_DIR}/fst
+			  ${PROJECT_SOURCE_DIR}/rxterm-headers
+)
 target_link_libraries(fastread fst z)
 if(Boost_FOUND)
     target_include_directories(fastread PUBLIC ${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
Samples of usage illustration:

> ./fastread 
> Usage: fastread:
>   -h [ --help ]         Show usage
>   -i [ --input ] arg    In filename
>   -o [ --output ] arg   Out filename
> 
>  ./fastread -h
> Usage: fastread:
>   -h [ --help ]         Show usage
>   -i [ --input ] arg    In filename
>   -o [ --output ] arg   Out filename
> 
> ./fastread --help
> Usage: fastread:
>   -h [ --help ]         Show usage
>   -i [ --input ] arg    In filename
>   -o [ --output ] arg   Out filename
> 